### PR TITLE
Break out of loop if not on an edge

### DIFF
--- a/nebula-unity/Assets/scripts/DungeonMapGenerator.cs
+++ b/nebula-unity/Assets/scripts/DungeonMapGenerator.cs
@@ -314,6 +314,9 @@ public class DungeonMapGenerator : MonoBehaviour {
 		*/
 		for (int i = -xLength; i <= xLength; ++i) {
 			for (int j = 0; j < yLength; ++j) {
+                // Break out if not on an edge
+                if ((i != -xLength || i != xLength) && (j != 0 || j != yLength - 1)) { continue; }
+
 				Tile curTile = null;
 
 				switch (direction) {


### PR DESCRIPTION
Currently CheckTiles checks EVERY TILE within a potential room.  This is unnecessary.  We can check just the edge tiles without information loss.  

Check the ticket for performance findings